### PR TITLE
Add custom model path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+01/12/2024
+ - Add custom model path
+ - Update README

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ rm model.tar.gz
 **Run ViraLM in one command:**
 
 ```
-python viralm.py [--input INPUT_FA] [--output OUTPUT_PTH] [--len MINIMUM_LEN] [--threshold THRESHOLD]
+python viralm.py [--input INPUT_FA] [--output OUTPUT_PTH] [--db DB_PATH] [--len MINIMUM_LEN] [--threshold THRESHOLD]
 ```
 
 **Options**
@@ -55,6 +55,8 @@ python viralm.py [--input INPUT_FA] [--output OUTPUT_PTH] [--len MINIMUM_LEN] [-
                         The path of your input fasta file
   --output OUTPUT_PTH
 			The path of your output diectory
+  -d DB, --db DB        
+                        Model directory
   --len MINIMUM_LEN
                         predict only for sequence >= len bp (default 500)
   --threshold THRESHOLD
@@ -68,6 +70,12 @@ Prediction on the example file:
 ```
 export CUDA_VISIBLE_DEVICES=0,1,2,...,n 	# (option) n is the number of GPUs
 python viralm.py --input test.fasta --out result --len 500 --threshold 0.5
+```
+
+If you prefer storing your models/databases in a different location, then you can use
+`-d` or `--db` parameter:
+```
+python viralm.py --input test.fasta --out result -d /path/database/downloaded --len 500 --threshold 0.5
 ```
 ## 4. Output explanation
 

--- a/viralm.py
+++ b/viralm.py
@@ -22,6 +22,7 @@ parser = argparse.ArgumentParser(description='ViraLM v1.0\nViraLM is a python li
                                              'nucleotide information to make prediction.')
 parser.add_argument('--input', type=str, help='name of the input file (fasta format)')
 parser.add_argument('--output', type=str, help='output directory', default='result')
+parser.add_argument('-d', '--db', type=str, help='model directory', default='model')
 parser.add_argument('--threads', type=int, help='number of threads if run on cpu', default=1)
 parser.add_argument('--batch_size', type=int, help='batch size for prediction', default=16)
 parser.add_argument('--len', type=int, help='predict only for sequences >= len bp (default: 500)', default=500)
@@ -30,12 +31,12 @@ inputs = parser.parse_args()
 
 input_pth = inputs.input
 output_pth = inputs.output
+model_pth = inputs.db
 batch_size = inputs.batch_size
 len_threshold = int(inputs.len)
 score_threshold = float(inputs.threshold)
 cpu_threads = int(inputs.threads)
 cache_dir = f'{output_pth}/cache'
-model_pth = 'model'
 filename = input_pth.rsplit('/')[-1].split('.')[0]
 
 if score_threshold < 0.5:


### PR DESCRIPTION
In some cases, users prefer to store databases/models in a centralised location. This added argument `-d` and `--db` provides this flexibility. The functionality has been tested and it works. Please feel free to integrate changes.